### PR TITLE
Add devcontainer for Flutter development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/cirruslabs/flutter:stable
+
+RUN apt-get update && \
+    apt-get install -y clang cmake ninja-build pkg-config chromium-browser wget unzip lib32stdc++6 lib32z1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Android Studio
+ARG ANDROID_STUDIO_VERSION=2024.1.1.21
+RUN wget -q https://redirector.gvt1.com/edgedl/android/studio/ide-zips/${ANDROID_STUDIO_VERSION}/android-studio-${ANDROID_STUDIO_VERSION}-linux.tar.gz -O /tmp/android-studio.tar.gz && \
+    mkdir -p /opt/android-studio && \
+    tar -xzf /tmp/android-studio.tar.gz -C /opt/android-studio --strip-components=1 && \
+    rm /tmp/android-studio.tar.gz && \
+    ln -s /opt/android-studio/bin/studio.sh /usr/local/bin/android-studio
+
+ENV CHROME_EXECUTABLE=/usr/bin/chromium-browser

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Flutter Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dart-code.flutter"
+            ]
+        }
+    },
+    "remoteEnv": {
+        "CHROME_EXECUTABLE": "/usr/bin/chromium-browser"
+    },
+    "postCreateCommand": "flutter doctor"
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Dev Container
+
+This repository includes a [devcontainer](https://containers.dev/) configuration.
+It uses the `ghcr.io/cirruslabs/flutter:stable` image which provides Flutter with
+the Android SDK and common desktop dependencies preinstalled. The container also
+downloads and installs Android Studio so that all `flutter doctor` checks pass.
+After opening the project in a container-aware editor like VS Code, the
+environment will run `flutter doctor` automatically to verify your setup.


### PR DESCRIPTION
## Summary
- provide a devcontainer using `ghcr.io/cirruslabs/flutter:stable`
- install common build tools and Chromium for Flutter web
- install Android Studio so `flutter doctor` passes
- run `flutter doctor` after container creation
- document devcontainer usage in README

## Testing
- `apt-get update`
- `apt-get install -y clang cmake ninja-build pkg-config chromium-browser wget unzip lib32stdc++6 lib32z1`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f435ab1c8331a4c907c5e888ca86