### PR TITLE
Fix dashboard categories and item list handling

### DIFF
--- a/lib/view/dashboard_view.dart
+++ b/lib/view/dashboard_view.dart
@@ -2,35 +2,42 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 import '../view_model/dashboard_view_model.dart';
+import '../view_model/categoria_view_model.dart';
 
-class DashboardView extends StatelessWidget {
+class DashboardView extends StatefulWidget {
+  const DashboardView({super.key});
 
-  // Dados para o Gráfico de Pizza serão construídos dinamicamente
+  @override
+  State<DashboardView> createState() => _DashboardViewState();
+}
 
-  // Dados para o Gráfico de Linha (FL_CHART)
-  final List<FlSpot> _lineSpots = [
-    FlSpot(0, 900), // Mar
-    FlSpot(1, 1100), // Abr
-    FlSpot(2, 1250), // Mai
-    FlSpot(3, 1000), // Jun
-    FlSpot(4, 1350), // Jul
-    FlSpot(5, 1250), // Ago
-  ];
+class _DashboardViewState extends State<DashboardView> {
+  // Dados para o Gráfico de Pizza e de Linha serão construídos dinamicamente
 
-  // Labels para o eixo X do gráfico de linha
-  final List<String> _lineLabels = ['Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago'];
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() => context.read<DashboardViewModel>().carregarResumo());
+  }
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.watch<DashboardViewModel>();
+    if (vm.loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
     return Scaffold(
       appBar: AppBar(
-        title: Text('Dashboard de Gastos'),
+        title: const Text('Dashboard de Gastos'),
         centerTitle: true,
       ),
       body: ListView(
         children: [
-          _buildStatsCards(context), // Passe o contexto explicitamente aqui
+          _buildStatsCards(context),
           _buildLineChart(),
           _buildPieChart(),
         ],
@@ -38,101 +45,137 @@ class DashboardView extends StatelessWidget {
     );
   }
 
-  // O método _buildStatCard precisa receber o contexto, já que DashboardView é StatelessWidget
   Widget _buildStatsCards(BuildContext context) {
+    final vm = context.watch<DashboardViewModel>();
+    final categorias = context.watch<CategoriaViewModel>().categorias;
+    final catMap = {for (final c in categorias) c.id: c.titulo};
+
+    final cards = <Widget>[
+      _buildStatCard(
+          context, 'Total no Mês', 'R\$ ${vm.resumo.totalGastos.toStringAsFixed(2)}'),
+      _buildStatCard(context, 'Transações', vm.transacoes.toString()),
+      ...vm.resumo.totalPorCategoria.entries.map(
+        (e) => _buildStatCard(
+          context,
+          catMap[e.key] ?? 'Categoria ${e.key}',
+          'R\$ ${e.value.toStringAsFixed(2)}',
+        ),
+      ),
+    ];
+
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Wrap(
         alignment: WrapAlignment.center,
         spacing: 8.0,
         runSpacing: 8.0,
-        children: [
-          _buildStatCard(context, 'Total no Mês', 'R\$ ${context.watch<DashboardViewModel>().resumo.totalGastos.toStringAsFixed(2)}'),
-          _buildStatCard(context, 'Transações', context.watch<DashboardViewModel>().transacoes.toString()),
-          _buildStatCard(context, 'Alimentação', 'R\$ ${context.watch<DashboardViewModel>().resumo.totalPorCategoria['Alimentação']?.toStringAsFixed(2) ?? '0.00'}'),
-          _buildStatCard(context, 'Transporte', 'R\$ ${context.watch<DashboardViewModel>().resumo.totalPorCategoria['Transporte']?.toStringAsFixed(2) ?? '0.00'}'),
-        ],
+        children: cards,
       ),
     );
   }
 
-  // Este método já recebe o contexto, está correto
   Widget _buildStatCard(BuildContext context, String title, String value) {
     return Container(
       width: MediaQuery.of(context).size.width / 2 - 20,
-      padding: EdgeInsets.all(12),
-      margin: EdgeInsets.all(4),
+      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.all(4),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(8),
-        boxShadow: [BoxShadow(blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: Offset(0, 1))],
+        boxShadow: [
+          BoxShadow(
+              blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: const Offset(0, 1))
+        ],
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text(title, style: TextStyle(fontSize: 16, color: Colors.blue)),
-          Text(value, style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          Text(title, style: const TextStyle(fontSize: 16, color: Colors.blue)),
+          Text(value,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
         ],
       ),
     );
   }
 
   Widget _buildLineChart() {
+    final vm = context.watch<DashboardViewModel>();
+    final months = vm.gastosPorMes.keys.toList();
+    final values = vm.gastosPorMes.values.toList();
+
+    final spots = [
+      for (int i = 0; i < values.length; i++)
+        FlSpot(i.toDouble(), values[i])
+    ];
+
+    final labels = months
+        .map((d) => DateFormat('MMM', 'pt_BR').format(d))
+        .toList();
+
+    final maxY =
+        values.isEmpty ? 0.0 : (values.reduce((a, b) => a > b ? a : b) * 1.2);
+
     return Container(
       height: 300,
-      margin: EdgeInsets.all(8),
-      padding: EdgeInsets.all(16),
+      margin: const EdgeInsets.all(8),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(8),
-        boxShadow: [BoxShadow(blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: Offset(0, 1))],
+        boxShadow: [
+          BoxShadow(
+              blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: const Offset(0, 1))
+        ],
       ),
       child: Column(
         children: [
-          Text('Evolução de Gastos (Últimos 6 meses)', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const Text('Evolução de Gastos (Últimos 6 meses)',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           Expanded(
             child: LineChart(
               LineChartData(
-                gridData: FlGridData(show: true), // Mostrar grade
+                gridData: FlGridData(show: true),
                 titlesData: FlTitlesData(
                   show: true,
-                  leftTitles: AxisTitles(
-                    sideTitles: SideTitles(showTitles: true, reservedSize: 40), // Eixo Y
-                  ),
+                  leftTitles:
+                      AxisTitles(sideTitles: SideTitles(showTitles: true, reservedSize: 40)),
                   bottomTitles: AxisTitles(
                     sideTitles: SideTitles(
                       showTitles: true,
                       reservedSize: 30,
                       getTitlesWidget: (value, meta) {
-                        // Converte o valor numérico do eixo X para a label do mês
+                        final idx = value.toInt();
+                        if (idx < 0 || idx >= labels.length) return const SizedBox.shrink();
                         return SideTitleWidget(
                           axisSide: meta.axisSide,
                           space: 8,
-                          child: Text(_lineLabels[value.toInt()]),
+                          child: Text(labels[idx]),
                         );
                       },
                     ),
                   ),
-                  topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)), // Não mostrar títulos em cima
-                  rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)), // Não mostrar títulos na direita
+                  topTitles:
+                      AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  rightTitles:
+                      AxisTitles(sideTitles: SideTitles(showTitles: false)),
                 ),
-                borderData: FlBorderData( // Bordas do gráfico
+                borderData: FlBorderData(
                   show: true,
                   border: Border.all(color: const Color(0xff37434d), width: 1),
                 ),
                 minX: 0,
-                maxX: 5, // 6 meses (índices de 0 a 5)
+                maxX: (values.length - 1).toDouble(),
                 minY: 0,
-                maxY: 1500, // Ajuste este valor conforme o máximo esperado dos seus gastos
+                maxY: maxY == 0 ? 1 : maxY,
                 lineBarsData: [
                   LineChartBarData(
-                    spots: _lineSpots, // Seus pontos de dados
-                    isCurved: true, // Curva suave
+                    spots: spots,
+                    isCurved: true,
                     color: Colors.blue,
                     barWidth: 3,
                     isStrokeCapRound: true,
-                    dotData: FlDotData(show: true), // Mostrar pontos nos dados
-                    belowBarData: BarAreaData(show: false), // Não preencher área abaixo da linha
+                    dotData: FlDotData(show: true),
+                    belowBarData: BarAreaData(show: false),
                   ),
                 ],
               ),
@@ -146,34 +189,43 @@ class DashboardView extends StatelessWidget {
   Widget _buildPieChart() {
     return Container(
       height: 300,
-      margin: EdgeInsets.all(8),
-      padding: EdgeInsets.all(16),
+      margin: const EdgeInsets.all(8),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(8),
-        boxShadow: [BoxShadow(blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: Offset(0, 1))],
+        boxShadow: [
+          BoxShadow(
+              blurRadius: 2, color: Colors.grey.withOpacity(0.2), offset: const Offset(0, 1))
+        ],
       ),
       child: Column(
         children: [
-          Text('Distribuição por Categoria', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const Text('Distribuição por Categoria',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           Expanded(
-            child: Consumer<DashboardViewModel>(
-              builder: (context, vm, _) {
-                final sections = vm.resumo.totalPorCategoria.entries
-                    .map(
-                      (e) => PieChartSectionData(
-                        color: Colors.blue,
-                        value: e.value,
-                        title: '${e.key}\nR\$${e.value.toStringAsFixed(0)}',
-                        radius: 60,
-                        titleStyle: const TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white),
-                        titlePositionPercentageOffset: 0.55,
-                      ),
-                    )
-                    .toList();
+            child: Consumer2<DashboardViewModel, CategoriaViewModel>(
+              builder: (context, vm, catVm, _) {
+                final catMap = {for (final c in catVm.categorias) c.id: c.titulo};
+                final entries = vm.resumo.totalPorCategoria.entries.toList();
+                final sections = <PieChartSectionData>[];
+                for (int i = 0; i < entries.length; i++) {
+                  final e = entries[i];
+                  sections.add(
+                    PieChartSectionData(
+                      color: Colors.primaries[i % Colors.primaries.length],
+                      value: e.value,
+                      title:
+                          '${catMap[e.key] ?? 'Cat'}\nR\$${e.value.toStringAsFixed(0)}',
+                      radius: 60,
+                      titleStyle: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white),
+                      titlePositionPercentageOffset: 0.55,
+                    ),
+                  );
+                }
                 return PieChart(
                   PieChartData(
                     sections: sections,

--- a/lib/view/gasto_view.dart
+++ b/lib/view/gasto_view.dart
@@ -24,6 +24,9 @@ class _GastoViewState extends State<GastoView> {
   List<Map<String, dynamic>> _produtos = [
     {'descricao': '', 'quantidade': '', 'preco': '', 'categoria': ''}
   ];
+  final List<TextEditingController> _descControllers = [];
+  final List<TextEditingController> _qtdControllers = [];
+  final List<TextEditingController> _precoControllers = [];
   final TextEditingController _totalController = TextEditingController();
 
   @override
@@ -31,6 +34,10 @@ class _GastoViewState extends State<GastoView> {
     super.initState();
     if (widget.dadosIniciais != null) {
       _preencherDadosIniciais(widget.dadosIniciais!);
+    } else {
+      _descControllers.add(TextEditingController());
+      _qtdControllers.add(TextEditingController());
+      _precoControllers.add(TextEditingController());
     }
   }
 
@@ -53,14 +60,22 @@ class _GastoViewState extends State<GastoView> {
     if (itens.isNotEmpty) {
       final categorias = context.read<CategoriaViewModel>().categorias;
       final cat = categorias.isNotEmpty ? categorias.first.titulo : 'Outros';
-      _produtos = itens.map((item) {
-        return {
-          'descricao': item['nome'] ?? '',
-          'quantidade': item['qtd']?.toString() ?? '1',
-          'preco': item['valor_unitario']?.toStringAsFixed(2) ?? '0.00',
-          'categoria': cat
-        };
-      }).toList();
+      _produtos = itens
+          .map((item) => {
+                'descricao': item['nome'] ?? '',
+                'quantidade': item['qtd']?.toString() ?? '1',
+                'preco': item['valor_unitario']?.toStringAsFixed(2) ?? '0.00',
+                'categoria': cat
+              })
+          .toList();
+    }
+    _descControllers.clear();
+    _qtdControllers.clear();
+    _precoControllers.clear();
+    for (final p in _produtos) {
+      _descControllers.add(TextEditingController(text: p['descricao']));
+      _qtdControllers.add(TextEditingController(text: p['quantidade']));
+      _precoControllers.add(TextEditingController(text: p['preco']));
     }
 
     _totalController.text =
@@ -72,6 +87,15 @@ class _GastoViewState extends State<GastoView> {
     _estabelecimentoController.dispose();
     _localidadeController.dispose();
     _totalController.dispose();
+    for (final c in _descControllers) {
+      c.dispose();
+    }
+    for (final c in _qtdControllers) {
+      c.dispose();
+    }
+    for (final c in _precoControllers) {
+      c.dispose();
+    }
     super.dispose();
   }
 
@@ -81,6 +105,9 @@ class _GastoViewState extends State<GastoView> {
     setState(() {
       _produtos.add(
           {'descricao': '', 'quantidade': '', 'preco': '', 'categoria': cat});
+      _descControllers.add(TextEditingController());
+      _qtdControllers.add(TextEditingController());
+      _precoControllers.add(TextEditingController());
     });
   }
 
@@ -248,14 +275,11 @@ class _GastoViewState extends State<GastoView> {
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
           SizedBox(height: 8),
           ..._produtos.asMap().entries.map((entry) {
+            final index = entry.key;
             Map<String, dynamic> produto = entry.value;
-            // Cria controllers para cada campo de produto para poder preenchê-los
-            final descController =
-                TextEditingController(text: produto['descricao']);
-            final qtdController =
-                TextEditingController(text: produto['quantidade']);
-            final precoController =
-                TextEditingController(text: produto['preco']);
+            final descController = _descControllers[index];
+            final qtdController = _qtdControllers[index];
+            final precoController = _precoControllers[index];
 
             return Padding(
               padding: const EdgeInsets.only(bottom: 8.0),

--- a/lib/view_model/dashboard_view_model.dart
+++ b/lib/view_model/dashboard_view_model.dart
@@ -2,6 +2,7 @@ import 'package:expenses_control/models/data/gasto_repository.dart';
 import 'package:expenses_control/models/statistics/estatistica_dto.dart';
 import 'package:flutter/material.dart';
 import 'package:expenses_control_app/models/services/statistica_service.dart';
+import 'package:expenses_control/models/gasto.dart';
 
 class DashboardViewModel extends ChangeNotifier {
   final GastoRepository _repo;
@@ -12,18 +13,37 @@ class DashboardViewModel extends ChangeNotifier {
   EstatisticaDTO _resumo = EstatisticaDTO.vazio;
   bool _loading = false;
   int _transacoes = 0;
+  Map<DateTime, double> _gastosPorMes = const {};
 
   EstatisticaDTO get resumo => _resumo;
   bool get loading => _loading;
   int get transacoes => _transacoes;
+  Map<DateTime, double> get gastosPorMes => _gastosPorMes;
 
   Future<void> carregarResumo() async {
     _loading = true;
     notifyListeners();
+
     final gastos = await _repo.findAll();
     _transacoes = gastos.length;
     _resumo = _stats.gerarResumo(gastos);
+    _gastosPorMes = _calcularGastosPorMes(gastos);
+
     _loading = false;
     notifyListeners();
+  }
+
+  Map<DateTime, double> _calcularGastosPorMes(List<Gasto> gastos) {
+    final now = DateTime.now();
+    final months = List.generate(
+        6, (i) => DateTime(now.year, now.month - (5 - i), 1));
+    final map = {for (final m in months) m: 0.0};
+    for (final g in gastos) {
+      final key = DateTime(g.data.year, g.data.month, 1);
+      if (map.containsKey(key)) {
+        map[key] = map[key]! + g.total;
+      }
+    }
+    return map;
   }
 }


### PR DESCRIPTION
## Summary
- load monthly data and category totals in `DashboardViewModel`
- update dashboard charts and stat cards to use real data
- keep item TextEditingControllers for each product in `GastoView`
- show dynamic pie chart labels using category titles

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c1fe1b98833199a5acdc9879b243