### PR TITLE
Add category parent selection dialog

### DIFF
--- a/lib/view/categoria_view.dart
+++ b/lib/view/categoria_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../view_model/categoria_view_model.dart';
+import '../view_model/usuario_view_model.dart';
+import 'package:expenses_control/models/categoria.dart';
 
 class CategoriaView extends StatefulWidget {
   @override
@@ -8,6 +10,15 @@ class CategoriaView extends StatefulWidget {
 }
 
 class _CategoriaViewState extends State<CategoriaView> {
+  Categoria? _findCategoryById(List<Categoria> categorias, int? id) {
+    if (id == null) return null;
+    try {
+      return categorias.firstWhere((c) => c.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
   void _deleteCategory(BuildContext context, int id) {
     showDialog(
       context: context,
@@ -28,6 +39,149 @@ class _CategoriaViewState extends State<CategoriaView> {
                 await context.read<CategoriaViewModel>().deletarCategoria(id);
                 if (mounted) Navigator.of(context).pop();
               },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showAddCategoryDialog(BuildContext context) {
+    final tituloCtrl = TextEditingController();
+    final descCtrl = TextEditingController();
+    int? parentId;
+
+    showDialog(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: Text('Nova Categoria'),
+          content: StatefulBuilder(
+            builder: (ctx, setState) {
+              final categorias = context.read<CategoriaViewModel>().categorias;
+              return SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: tituloCtrl,
+                      decoration: InputDecoration(hintText: 'Título'),
+                    ),
+                    SizedBox(height: 8),
+                    TextField(
+                      controller: descCtrl,
+                      decoration: InputDecoration(hintText: 'Descrição'),
+                    ),
+                    SizedBox(height: 8),
+                    DropdownButtonFormField<int?>(
+                      value: parentId,
+                      decoration: InputDecoration(labelText: 'Categoria Pai'),
+                      items: [
+                        DropdownMenuItem<int?>(value: null, child: Text('Nenhuma')),
+                        ...categorias
+                            .map((c) => DropdownMenuItem<int?>(
+                                  value: c.id,
+                                  child: Text(c.titulo),
+                                ))
+                            .toList(),
+                      ],
+                      onChanged: (v) => setState(() => parentId = v),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final usuarioId =
+                    context.read<UsuarioViewModel>().usuarioLogado?.id ?? 0;
+                await context.read<CategoriaViewModel>().adicionarCategoria(
+                      tituloCtrl.text,
+                      descCtrl.text,
+                      usuarioId,
+                      parentId: parentId,
+                    );
+                if (mounted) Navigator.of(ctx).pop();
+              },
+              child: Text('Salvar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showEditCategoryDialog(BuildContext context, Categoria categoria) {
+    final tituloCtrl = TextEditingController(text: categoria.titulo);
+    final descCtrl = TextEditingController(text: categoria.descricao);
+    int? parentId = categoria.parentId;
+
+    showDialog(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: Text('Editar Categoria'),
+          content: StatefulBuilder(
+            builder: (ctx, setState) {
+              final categorias = context.read<CategoriaViewModel>().categorias
+                  .where((c) => c.id != categoria.id)
+                  .toList();
+              return SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: tituloCtrl,
+                      decoration: InputDecoration(hintText: 'Título'),
+                    ),
+                    SizedBox(height: 8),
+                    TextField(
+                      controller: descCtrl,
+                      decoration: InputDecoration(hintText: 'Descrição'),
+                    ),
+                    SizedBox(height: 8),
+                    DropdownButtonFormField<int?>(
+                      value: parentId,
+                      decoration: InputDecoration(labelText: 'Categoria Pai'),
+                      items: [
+                        DropdownMenuItem<int?>(value: null, child: Text('Nenhuma')),
+                        ...categorias
+                            .map((c) => DropdownMenuItem<int?>(
+                                  value: c.id,
+                                  child: Text(c.titulo),
+                                ))
+                            .toList(),
+                      ],
+                      onChanged: (v) => setState(() => parentId = v),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () async {
+                await context.read<CategoriaViewModel>().atualizarCategoria(
+                      categoria.copyWith(
+                        titulo: tituloCtrl.text,
+                        descricao: descCtrl.text,
+                        parentId: parentId,
+                      ),
+                    );
+                if (mounted) Navigator.of(ctx).pop();
+              },
+              child: Text('Salvar'),
             ),
           ],
         );
@@ -56,12 +210,20 @@ class _CategoriaViewState extends State<CategoriaView> {
         //   ),
         // ],
       ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showAddCategoryDialog(context),
+        child: Icon(Icons.add),
+      ),
       body: Consumer<CategoriaViewModel>(
         builder: (context, vm, _) => ListView.builder(
           padding: EdgeInsets.all(16.0),
           itemCount: vm.categorias.length,
           itemBuilder: (context, index) {
             final category = vm.categorias[index];
+            final parent = _findCategoryById(vm.categorias, category.parentId);
+            final displayTitle = parent != null
+                ? '${parent.titulo} > ${category.titulo}'
+                : category.titulo;
             return Card(
               margin: EdgeInsets.only(bottom: 8.0),
               elevation: 1,
@@ -72,49 +234,12 @@ class _CategoriaViewState extends State<CategoriaView> {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text(category.titulo, style: TextStyle(fontSize: 16)),
+                    Text(displayTitle, style: TextStyle(fontSize: 16)),
                     Row(
                       children: [
                         ElevatedButton(
-                          onPressed: () {
-                            showDialog(
-                              context: context,
-                              builder: (BuildContext context) {
-                                TextEditingController _editController =
-                                    TextEditingController(
-                                        text: category.titulo);
-                                return AlertDialog(
-                                  title: Text('Renomear Categoria'),
-                                  content: TextField(
-                                    controller: _editController,
-                                    decoration: InputDecoration(
-                                        hintText: 'Novo nome da categoria'),
-                                  ),
-                                  actions: <Widget>[
-                                    TextButton(
-                                      child: Text('Cancelar'),
-                                      onPressed: () {
-                                        Navigator.of(context).pop();
-                                      },
-                                    ),
-                                    TextButton(
-                                      child: Text('Salvar'),
-                                      onPressed: () async {
-                                        await context
-                                            .read<CategoriaViewModel>()
-                                            .atualizarCategoria(
-                                              category.copyWith(
-                                                  titulo: _editController.text),
-                                            );
-                                        if (mounted)
-                                          Navigator.of(context).pop();
-                                      },
-                                    ),
-                                  ],
-                                );
-                              },
-                            );
-                          },
+                          onPressed: () =>
+                              _showEditCategoryDialog(context, category),
                           style: ElevatedButton.styleFrom(
                             backgroundColor: Colors.orange,
                             foregroundColor: Colors.white,

--- a/lib/view_model/categoria_view_model.dart
+++ b/lib/view_model/categoria_view_model.dart
@@ -20,9 +20,15 @@ class CategoriaViewModel extends ChangeNotifier {
   }
 
   Future<void> adicionarCategoria(
-      String titulo, String descricao, int usuarioId) async {
+      String titulo, String descricao, int usuarioId,
+      {int? parentId}) async {
     await _repo.create(
-      Categoria(titulo: titulo, descricao: descricao, usuarioId: usuarioId),
+      Categoria(
+        titulo: titulo,
+        descricao: descricao,
+        usuarioId: usuarioId,
+        parentId: parentId,
+      ),
     );
     await carregarCategorias();
   }
@@ -30,6 +36,15 @@ class CategoriaViewModel extends ChangeNotifier {
   Future<void> atualizarCategoria(Categoria categoria) async {
     await _repo.update(categoria);
     await carregarCategorias();
+  }
+
+  Categoria? obterPorId(int? id) {
+    if (id == null) return null;
+    try {
+      return _categorias.firstWhere((c) => c.id == id);
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<void> deletarCategoria(int id) async {


### PR DESCRIPTION
## Summary
- allow specifying parent category when creating a new category
- add floating action button in category screen to trigger the dialog
- show parent category in list and allow editing parent

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498837fa308331b3774b871eead00e