### PR TITLE
Add Gemini text expense input

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:expenses_control_app/view/main_view.dart';
 import 'package:expenses_control_app/models/services/web_scrapping_service.dart';
+import 'package:expenses_control_app/models/services/gemini_service.dart';
+import 'package:expenses_control_app/utils/secrets.dart';
 import 'package:expenses_control_app/view_model/gasto_view_model.dart';
 import 'package:expenses_control_app/view_model/extrato_view_model.dart';
 import 'package:expenses_control_app/view_model/dashboard_view_model.dart';
@@ -53,10 +55,12 @@ void main() async {
         Provider(create: (_) => GastoRepository(db)),
         Provider(create: (_) => DashboardService()),
         Provider(create: (_) => WebScrapingService()),
+        Provider(create: (_) => GeminiService(geminiApiKey)),
         ChangeNotifierProvider(
           create: (ctx) => GastoViewModel(
             webScrapingService: ctx.read<WebScrapingService>(),
             repo: ctx.read<GastoRepository>(),
+            geminiService: ctx.read<GeminiService>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/models/services/gemini_service.dart
+++ b/lib/models/services/gemini_service.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'package:google_generative_ai/google_generative_ai.dart';
+
+class GeminiService {
+  final GenerativeModel _model;
+
+  GeminiService(String apiKey)
+      : _model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+
+  Future<Map<String, dynamic>> analisarTextoGasto(String texto) async {
+    final prompt = '''Extraia os dados de gasto descritos abaixo e responda apenas em JSON no formato:
+{
+  "estabelecimento": {"nome": "", "endereco_completo": ""},
+  "itens": [{"nome": "", "qtd": 1, "valor_unitario": 0.0}],
+  "compra": {"valor_a_pagar": 0.0},
+  "informacao_geral": {"data_hora_emissao": ""}
+}
+Frase: "$texto"''';
+
+    final response = await _model.generateContent([Content.text(prompt)]);
+    final jsonString = response.text ?? '{}';
+    return jsonDecode(jsonString) as Map<String, dynamic>;
+  }
+}

--- a/lib/utils/secrets.dart
+++ b/lib/utils/secrets.dart
@@ -1,0 +1,1 @@
+const String geminiApiKey = String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');

--- a/lib/view/adicionar_gasto_view.dart
+++ b/lib/view/adicionar_gasto_view.dart
@@ -65,6 +65,48 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
     }
   }
 
+  void _showTextInputDialog() async {
+    final controller = TextEditingController();
+    final text = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Descreva sua compra'),
+        content: TextField(
+          controller: controller,
+          maxLines: 3,
+          decoration: InputDecoration(hintText: 'Ex: Comprei 5 p\u00e3es no mercado'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: Text('Processar'),
+          ),
+        ],
+      ),
+    );
+
+    if (text != null && text.trim().isNotEmpty && mounted) {
+      final viewModel = context.read<GastoViewModel>();
+      final success = await viewModel.processarTextoGasto(text);
+      if (success && mounted) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => GastoView(dadosIniciais: viewModel.scrapedData),
+          ),
+        );
+      } else if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(viewModel.errorMessage ?? 'Falha ao processar texto.')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<GastoViewModel>(
@@ -145,6 +187,20 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
                       ),
                     ),
                     label: Text('Inserir Manualmente', style: TextStyle(fontSize: 18)),
+                  ),
+                  SizedBox(height: 12),
+                  OutlinedButton.icon(
+                    icon: Icon(Icons.text_fields),
+                    onPressed: _showTextInputDialog,
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(color: Colors.blue, width: 1.5),
+                      foregroundColor: Colors.blue,
+                      padding: EdgeInsets.symmetric(horizontal: 40, vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    label: Text('Inserir via Texto', style: TextStyle(fontSize: 18)),
                   ),
                 ],
               ),

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -1,17 +1,21 @@
 import 'package:expenses_control/models/data/gasto_repository.dart';
 import 'package:expenses_control_app/models/services/web_scrapping_service.dart';
+import 'package:expenses_control_app/models/services/gemini_service.dart';
 import 'package:expenses_control/models/gasto.dart';
 import 'package:flutter/material.dart';
 
 class GastoViewModel extends ChangeNotifier {
   final WebScrapingService _webScrapingService;
   final GastoRepository _repo;
+  final GeminiService _geminiService;
 
   GastoViewModel({
     required WebScrapingService webScrapingService,
     required GastoRepository repo,
+    required GeminiService geminiService,
   })  : _webScrapingService = webScrapingService,
-        _repo = repo;
+        _repo = repo,
+        _geminiService = geminiService;
 
   bool _isLoading = false;
   String? _errorMessage;
@@ -43,6 +47,25 @@ class GastoViewModel extends ChangeNotifier {
 
     try {
       _scrapedData = await _webScrapingService.scrapeNfceFromUrl(url);
+      _isLoading = false;
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _errorMessage = e.toString();
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> processarTextoGasto(String texto) async {
+    _isLoading = true;
+    _errorMessage = null;
+    _scrapedData = null;
+    notifyListeners();
+
+    try {
+      _scrapedData = await _geminiService.analisarTextoGasto(texto);
       _isLoading = false;
       notifyListeners();
       return true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   month_picker_dialog: 6.2.3 # Adicione novamente se você quiser usá-lo
   mobile_scanner: ^5.1.1 
   url_launcher: ^6.2.2
+  google_generative_ai: ^0.4.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate Gemini service for text-based expense extraction
- allow providing Gemini API key via `geminiApiKey`
- inject `GeminiService` into view models
- add "Inserir via Texto" option and dialog
- support parsing text with Gemini to pre-fill expenses
- add `google_generative_ai` dependency

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859536b2a588331b5d6f090e1672769