### PR TITLE
Improve error display in expense screens

### DIFF
--- a/lib/view/adicionar_gasto_view.dart
+++ b/lib/view/adicionar_gasto_view.dart
@@ -167,6 +167,14 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
                     ),
                     label: Text('Inserir Manualmente', style: TextStyle(fontSize: 18)),
                   ),
+                  if (viewModel.errorMessage != null) ...[
+                    SizedBox(height: 16),
+                    Text(
+                      viewModel.errorMessage!,
+                      style: TextStyle(color: Colors.red),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ],
               ),
               // Indicador de Carregamento

--- a/lib/view/gemini_text_view.dart
+++ b/lib/view/gemini_text_view.dart
@@ -63,6 +63,14 @@ class _GeminiTextViewState extends State<GeminiTextView> {
                       onPressed: _submit,
                       child: const Text('Enviar'),
                     ),
+              if (vm.errorMessage != null) ...[
+                const SizedBox(height: 16),
+                Text(
+                  vm.errorMessage!,
+                  style: const TextStyle(color: Colors.red),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -42,7 +42,8 @@ class GastoViewModel extends ChangeNotifier {
       notifyListeners();
       return true;
     } catch (e) {
-      _errorMessage = e.toString();
+      _errorMessage =
+          e.toString().replaceFirst(RegExp(r'^Exception: ?'), '');
       _isLoading = false;
       notifyListeners();
       return false;
@@ -69,7 +70,8 @@ class GastoViewModel extends ChangeNotifier {
       notifyListeners();
       return true;
     } catch (e) {
-      _errorMessage = e.toString();
+      _errorMessage =
+          e.toString().replaceFirst(RegExp(r'^Exception: ?'), '');
       _isLoading = false;
       notifyListeners();
       return false;


### PR DESCRIPTION
## Summary
- show error text in Gemini text form
- show error text after QR scan fails
- strip `Exception:` prefix from error messages for readability

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bce4bd6c8331a74b5fe6eae985f3