### PR TITLE
Fix meta screen date selection

### DIFF
--- a/lib/models/meta.dart
+++ b/lib/models/meta.dart
@@ -21,14 +21,26 @@ class Meta with EntityMapper {
   @override
   String get tableName => 'metas';
 
-  factory Meta.fromMap(Map<String, dynamic> map) => Meta(
-        id: map['id'] as int?,
-        descricao: map['descricao'] as String? ?? '',
-        valorLimite: (map['valor_limite'] as num).toDouble(),
-        mesAno: DateTime.parse(map['mes_ano'] as String),
-        usuarioId: map['usuario_id'] as int,
-        categoriaId: map['categoria_id'] as int?,
+  factory Meta.fromMap(Map<String, dynamic> map) {
+    if (map.isEmpty) {
+      return Meta(
+        descricao: '',
+        valorLimite: 0.0,
+        mesAno: DateTime.now(),
+        usuarioId: 0,
       );
+    }
+    return Meta(
+      id: map['id'] as int?,
+      descricao: map['descricao'] as String? ?? '',
+      valorLimite: (map['valor_limite'] as num?)?.toDouble() ?? 0.0,
+      mesAno: map['mes_ano'] != null
+          ? DateTime.parse(map['mes_ano'] as String)
+          : DateTime.now(),
+      usuarioId: (map['usuario_id'] as int?) ?? 0,
+      categoriaId: map['categoria_id'] as int?,
+    );
+  }
 
   @override
   Map<String, dynamic> toMap() => {

--- a/lib/models/notificacao.dart
+++ b/lib/models/notificacao.dart
@@ -21,16 +21,27 @@ class Notificacao with EntityMapper {
   @override
   String get tableName => 'notificacoes';
 
-  factory Notificacao.fromMap(Map<String, dynamic> map) => Notificacao(
-        id: map['id'] as int?,
-        tipo: NotificationTipo.values.firstWhere(
-          (e) => e.name == map['tipo'],
-          orElse: () => NotificationTipo.LEMBRETE,
-        ),
-        mensagem: map['mensagem'] as String? ?? '',
-        data: DateTime.parse(map['data'] as String),
-        lida: (map['lida'] as int?) == 1,
+  factory Notificacao.fromMap(Map<String, dynamic> map) {
+    if (map.isEmpty) {
+      return Notificacao(
+        tipo: NotificationTipo.LEMBRETE,
+        mensagem: '',
+        data: DateTime.now(),
       );
+    }
+    return Notificacao(
+      id: map['id'] as int?,
+      tipo: NotificationTipo.values.firstWhere(
+        (e) => e.name == map['tipo'],
+        orElse: () => NotificationTipo.LEMBRETE,
+      ),
+      mensagem: map['mensagem'] as String? ?? '',
+      data: map['data'] != null
+          ? DateTime.parse(map['data'] as String)
+          : DateTime.now(),
+      lida: (map['lida'] as int?) == 1,
+    );
+  }
 
   @override
   Map<String, dynamic> toMap() => {

--- a/lib/view/meta_view.dart
+++ b/lib/view/meta_view.dart
@@ -15,7 +15,7 @@ class _MetaViewState extends State<MetaView> {
   void _showAddMetaDialog(BuildContext context) {
     final descCtrl = TextEditingController();
     final valorCtrl = TextEditingController();
-    DateTime mesAno = DateTime(DateTime.now().year, DateTime.now().month);
+    DateTime mesAno = DateTime.now();
     int? categoriaId;
 
     showDialog(
@@ -49,9 +49,9 @@ class _MetaViewState extends State<MetaView> {
                           initialDate: mesAno,
                           firstDate: DateTime(DateTime.now().year - 1),
                           lastDate: DateTime(DateTime.now().year + 1),
-                          helpText: 'Selecione o mês',
-                          fieldLabelText: 'Mês',
-                          fieldHintText: 'Mês/ano',
+                          helpText: 'Selecione o dia limite',
+                          fieldLabelText: 'Data',
+                          fieldHintText: 'dd/MM/yyyy',
                         );
                         if (picked != null) {
                           setState(() => mesAno = picked);
@@ -61,7 +61,7 @@ class _MetaViewState extends State<MetaView> {
                         children: [
                           const Icon(Icons.calendar_today),
                           const SizedBox(width: 8),
-                          Text(DateFormat('MM/yyyy').format(mesAno)),
+                          Text(DateFormat('dd/MM/yyyy').format(mesAno)),
                         ],
                       ),
                     ),
@@ -94,18 +94,34 @@ class _MetaViewState extends State<MetaView> {
             ),
             TextButton(
               onPressed: () async {
+                final descricao = descCtrl.text.trim();
+                final valorText = valorCtrl.text.replaceAll(',', '.');
+                final valor = double.tryParse(valorText);
+                if (descricao.isEmpty || valor == null) {
+                  ScaffoldMessenger.of(ctx).showSnackBar(
+                    const SnackBar(
+                        content: Text('Descrição e valor são obrigatórios')),
+                  );
+                  return;
+                }
+
                 final usuarioId =
                     context.read<UsuarioViewModel>().usuarioLogado?.id ?? 1;
+
                 await context.read<MetaViewModel>().adicionarMeta(
-                      Meta(
-                        descricao: descCtrl.text,
-                        valorLimite: double.tryParse(valorCtrl.text) ?? 0,
-                        mesAno: mesAno,
-                        categoriaId: categoriaId,
-                        usuarioId: usuarioId,
-                      ),
-                    );
+                  Meta(
+                    descricao: descricao,
+                    valorLimite: valor,
+                    mesAno: mesAno,
+                    categoriaId: categoriaId,
+                    usuarioId: usuarioId,
+                  ),
+                );
+
                 if (mounted) Navigator.of(ctx).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Meta salva com sucesso')),
+                );
               },
               child: const Text('Salvar'),
             ),
@@ -138,7 +154,7 @@ class _MetaViewState extends State<MetaView> {
           itemCount: vm.metas.length,
           itemBuilder: (context, index) {
             final meta = vm.metas[index];
-            final mes = DateFormat('MM/yyyy').format(meta.mesAno);
+            final mes = DateFormat('dd/MM/yyyy').format(meta.mesAno);
             return Card(
               margin: const EdgeInsets.only(bottom: 8.0),
               child: ListTile(


### PR DESCRIPTION
## Summary
- improve meta goal form: pick full date instead of just month
- validate inputs and show snackbar feedback

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a776aa6c0833190db22f9e7bf2e3a