### PR TITLE
Enable Gemini item categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ Comprei 5 pães de queijo no Zona Sul do Rio.
 ```
 
 O Gemini retornará um JSON estruturado e o formulário será preenchido
-automaticamente para revisão.
+automaticamente para revisão. A partir desta versão o modelo também
+classifica cada item na melhor categoria existente.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,6 +81,7 @@ void main() async {
             webScrapingService: ctx.read<WebScrapingService>(),
             geminiService: ctx.read<GeminiService>(),
             repo: ctx.read<GastoRepository>(),
+            categoriaRepo: ctx.read<CategoriaRepository>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/models/services/gemini_service.dart
+++ b/lib/models/services/gemini_service.dart
@@ -42,19 +42,25 @@ class GeminiService {
     }
   }
 
-  Future<Map<String, dynamic>> parseExpense(String text) async {
+  Future<Map<String, dynamic>> parseExpense(String text,
+      {List<String> categorias = const []}) async {
     final url = Uri.parse(
         'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' +
             apiKey);
+
+    final categoriasTexto = categorias.isNotEmpty
+        ? '\nClassifique cada item na melhor categoria dentre: ${categorias.join(', ')}.'
+        : '';
 
     final prompt =
         '''Converta a seguinte descricao de compra em JSON no formato:
 {
   "estabelecimento": {"nome": "", "endereco_completo": ""},
   "informacao_geral": {"data_hora_emissao": "dd/MM/yyyy HH:mm:ss"},
-  "itens": [{"nome": "", "qtd": numero, "valor_unitario": numero, "valor_total_item": numero}],
+  "itens": [{"nome": "", "qtd": numero, "valor_unitario": numero, "valor_total_item": numero, "categoria": ""}],
   "compra": {"valor_a_pagar": numero}
 }
+$categoriasTexto
 Retorne apenas o JSON sem explicacoes.
 $text''';
 

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:expenses_control/models/data/gasto_repository.dart';
+import 'package:expenses_control/models/data/categoria_repository.dart';
 import 'package:expenses_control_app/models/services/web_scrapping_service.dart';
 import 'package:expenses_control_app/models/services/gemini_service.dart';
 import 'package:expenses_control/models/gasto.dart';
@@ -8,14 +9,17 @@ class GastoViewModel extends ChangeNotifier {
   final WebScrapingService _webScrapingService;
   final GeminiService _geminiService;
   final GastoRepository _repo;
+  final CategoriaRepository _categoriaRepo;
 
   GastoViewModel({
     required WebScrapingService webScrapingService,
     required GeminiService geminiService,
     required GastoRepository repo,
+    required CategoriaRepository categoriaRepo,
   })  : _webScrapingService = webScrapingService,
         _geminiService = geminiService,
-        _repo = repo;
+        _repo = repo,
+        _categoriaRepo = categoriaRepo;
 
   bool _isLoading = false;
   String? _errorMessage;
@@ -37,7 +41,10 @@ class GastoViewModel extends ChangeNotifier {
     _scrapedData = null;
     notifyListeners();
     try {
-      _scrapedData = await _geminiService.parseExpense(texto);
+      final cats = await _categoriaRepo.findAll();
+      final nomesCategorias = cats.map((c) => c.titulo).toList();
+      _scrapedData =
+          await _geminiService.parseExpense(texto, categorias: nomesCategorias);
       _isLoading = false;
       notifyListeners();
       return true;


### PR DESCRIPTION
## Summary
- inject CategoriaRepository into `GastoViewModel`
- send registered categories to Gemini in `parseExpense`
- update provider creation in `main.dart`
- document new behavior in README

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7fa0f35c833183761985e2aa6524