### PR TITLE
Add Gemini HTML fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Comprei 5 pães de queijo no Zona Sul do Rio.
 
 O Gemini retornará um JSON estruturado e o formulário será preenchido
 automaticamente para revisão.
+
+### Falha no scraping de notas fiscais
+
+Quando a leitura direta da NFC-e pelo scraper falha, o aplicativo envia o
+HTML obtido da nota fiscal para o Gemini, que extrai os dados no mesmo formato
+JSON. Assim ainda é possível preencher a tela mesmo que o layout do site mude.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,7 +75,11 @@ void main() async {
             gemini: ctx.read<GeminiService>(),
           ),
         ),
-        Provider(create: (_) => WebScrapingService()),
+        Provider(
+          create: (ctx) => WebScrapingService(
+            geminiService: ctx.read<GeminiService>(),
+          ),
+        ),
         ChangeNotifierProvider(
           create: (ctx) => GastoViewModel(
             webScrapingService: ctx.read<WebScrapingService>(),

--- a/lib/models/services/gemini_service.dart
+++ b/lib/models/services/gemini_service.dart
@@ -92,6 +92,56 @@ $text''';
     }
   }
 
+  /// Faz o parsing dos dados de uma NFC-e a partir de seu HTML bruto
+  Future<Map<String, dynamic>> parseExpenseFromHtml(String html) async {
+    final url = Uri.parse(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' +
+            apiKey);
+
+    final prompt =
+        '''Extraia as informações da nota fiscal eletrônica abaixo e retorne apenas o JSON no formato:
+{
+  "estabelecimento": {"nome": "", "endereco_completo": ""},
+  "informacao_geral": {"data_hora_emissao": "dd/MM/yyyy HH:mm:ss"},
+  "itens": [{"nome": "", "qtd": numero, "valor_unitario": numero, "valor_total_item": numero}],
+  "compra": {"valor_a_pagar": numero}
+}
+HTML:
+$html''';
+
+    final body = jsonEncode({
+      'contents': [
+        {
+          'parts': [
+            {'text': prompt}
+          ]
+        }
+      ]
+    });
+
+    final response = await _client.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: body,
+    );
+
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body);
+      final String? answer =
+          data['candidates']?[0]?['content']?['parts']?[0]?['text'];
+      if (answer == null) {
+        throw Exception('Resposta invalida do Gemini');
+      }
+
+      final match = RegExp(r'\{[\s\S]*\}').firstMatch(answer);
+      final jsonString = match != null ? match.group(0) : answer;
+
+      return json.decode(jsonString!);
+    } else {
+      throw Exception('Erro na API Gemini: ${response.body}');
+    }
+  }
+
   Future<String> sugestaoParaMeta(
       String descricao, double gastoAtual, double limite) async {
     final prompt =


### PR DESCRIPTION
## Summary
- add `parseExpenseFromHtml` to `GeminiService`
- use Gemini as a fallback in `WebScrapingService`
- inject `GeminiService` into `WebScrapingService`
- document scraping fallback in README

## Testing
- `flutter test test/widget_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad2993a9c833195f7fd8be83f026c