### PR TITLE
Implement strategy pattern for expense inputs

### DIFF
--- a/lib/models/strategies/gasto_input_strategy.dart
+++ b/lib/models/strategies/gasto_input_strategy.dart
@@ -1,0 +1,3 @@
+abstract class GastoInputStrategy {
+  Future<Map<String, dynamic>> process(String input);
+}

--- a/lib/models/strategies/qr_code_input_strategy.dart
+++ b/lib/models/strategies/qr_code_input_strategy.dart
@@ -1,0 +1,14 @@
+import '../services/web_scrapping_service.dart';
+import 'gasto_input_strategy.dart';
+
+class QrCodeInputStrategy implements GastoInputStrategy {
+  final WebScrapingService _scrapingService;
+
+  QrCodeInputStrategy({required WebScrapingService scrapingService})
+      : _scrapingService = scrapingService;
+
+  @override
+  Future<Map<String, dynamic>> process(String input) {
+    return _scrapingService.scrapeNfceFromUrl(input);
+  }
+}

--- a/lib/models/strategies/text_input_strategy.dart
+++ b/lib/models/strategies/text_input_strategy.dart
@@ -1,0 +1,16 @@
+import '../services/gemini_service.dart';
+import 'gasto_input_strategy.dart';
+
+class TextInputStrategy implements GastoInputStrategy {
+  final GeminiService _geminiService;
+  final List<String> _categorias;
+
+  TextInputStrategy({required GeminiService geminiService, List<String> categorias = const []})
+      : _geminiService = geminiService,
+        _categorias = categorias;
+
+  @override
+  Future<Map<String, dynamic>> process(String input) {
+    return _geminiService.parseExpense(input, categorias: _categorias);
+  }
+}


### PR DESCRIPTION
## Summary
- add `GastoInputStrategy` abstraction
- implement `TextInputStrategy` and `QrCodeInputStrategy`
- refactor `GastoViewModel` to use the strategies

## Testing
- `flutter format lib/models/strategies lib/view_model/gasto_view_model.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c10014a808331b3759ad5729402a5