### PR TITLE
Add editable gasto detail screen

### DIFF
--- a/lib/view/extrato_view.dart
+++ b/lib/view/extrato_view.dart
@@ -4,7 +4,8 @@ import 'package:provider/provider.dart';
 import 'package:month_picker_dialog/month_picker_dialog.dart';
 import '../view_model/extrato_view_model.dart';
 import '../view_model/categoria_view_model.dart';
-import 'package:expenses_control/models/gasto.dart';
+import '../models/gasto.dart';
+import 'gasto_detalhe_view.dart';
 
 class ExtratoView extends StatefulWidget {
   @override
@@ -130,68 +131,60 @@ class _ExtratoViewState extends State<ExtratoView> {
   }
 
   Widget _buildGastosTable(List<Gasto> gastos, Map<int?, String> catMap) {
+    if (gastos.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(16.0),
+        child: Text('Nenhum gasto encontrado'),
+      );
+    }
+
+    final rows = gastos
+        .map(
+          (g) => DataRow(
+            cells: [
+              DataCell(Text(DateFormat('yyyy-MM-dd').format(g.data))),
+              DataCell(Text(catMap[g.categoriaId] ?? '')),
+              DataCell(Text('R\$ ${g.total.toStringAsFixed(2)}')),
+              DataCell(Text(g.local)),
+            ],
+            onSelectChanged: (_) {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => GastoDetalheView(gasto: g),
+                ),
+              );
+            },
+          ),
+        )
+        .toList();
+
     return Container(
-      margin: EdgeInsets.all(8),
+      margin: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(8),
         boxShadow: [
           BoxShadow(
-              blurRadius: 2,
-              color: Colors.grey.withOpacity(0.2),
-              offset: Offset(0, 1))
+            blurRadius: 2,
+            color: Colors.grey.withOpacity(0.2),
+            offset: const Offset(0, 1),
+          )
         ],
       ),
-      child: Table(
-        columnWidths: {
-          0: FlexColumnWidth(1.0),
-          1: FlexColumnWidth(2.0),
-          2: FlexColumnWidth(1.5),
-          3: FlexColumnWidth(0.8),
-          4: FlexColumnWidth(1.0),
-          5: FlexColumnWidth(1.0),
-          6: FlexColumnWidth(1.5),
-        },
-        border: TableBorder.all(color: Colors.grey.shade300),
-        children: [
-          TableRow(
-            decoration: BoxDecoration(color: Colors.grey.shade100),
-            children: [
-              _buildTableCell('Data', isHeader: true),
-              _buildTableCell('Descrição', isHeader: true),
-              _buildTableCell('Categoria', isHeader: true),
-              _buildTableCell('Qtd', isHeader: true),
-              _buildTableCell('Preço', isHeader: true),
-              _buildTableCell('Total', isHeader: true),
-              _buildTableCell('Local', isHeader: true),
-            ],
-          ),
-          ...gastos
-              .map((g) => TableRow(children: [
-                    _buildTableCell(DateFormat('yyyy-MM-dd').format(g.data)),
-                    _buildTableCell('-'),
-                    _buildTableCell(catMap[g.categoriaId] ?? ''),
-                    _buildTableCell('-'),
-                    _buildTableCell('-'),
-                    _buildTableCell('R\$ ${g.total.toStringAsFixed(2)}'),
-                    _buildTableCell(g.local),
-                  ]))
-              .toList(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTableCell(String text, {bool isHeader = false}) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Text(
-        text,
-        style: TextStyle(
-          fontWeight: isHeader ? FontWeight.bold : FontWeight.normal,
-          fontSize: isHeader ? 14 : 12,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.vertical,
+        child: DataTable(
+          columns: const [
+            DataColumn(label: Text('Data')),
+            DataColumn(label: Text('Categoria')),
+            DataColumn(label: Text('Total')),
+            DataColumn(label: Text('Local')),
+          ],
+          rows: rows,
         ),
       ),
     );
   }
+
 }

--- a/lib/view/gasto_detalhe_view.dart
+++ b/lib/view/gasto_detalhe_view.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/gasto.dart';
+import '../view_model/categoria_view_model.dart';
+import '../view_model/gasto_view_model.dart';
+import '../view_model/extrato_view_model.dart';
+
+class GastoDetalheView extends StatefulWidget {
+  final Gasto gasto;
+  const GastoDetalheView({super.key, required this.gasto});
+
+  @override
+  State<GastoDetalheView> createState() => _GastoDetalheViewState();
+}
+
+class _GastoDetalheViewState extends State<GastoDetalheView> {
+  late DateTime _data;
+  late TextEditingController _localController;
+  late TextEditingController _totalController;
+  int? _categoriaId;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = widget.gasto.data;
+    _localController = TextEditingController(text: widget.gasto.local);
+    _totalController =
+        TextEditingController(text: widget.gasto.total.toStringAsFixed(2));
+    _categoriaId = widget.gasto.categoriaId;
+  }
+
+  @override
+  void dispose() {
+    _localController.dispose();
+    _totalController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selecionarData() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _data,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) setState(() => _data = picked);
+  }
+
+  Future<void> _salvar() async {
+    final atualizado = widget.gasto.copyWith(
+      data: _data,
+      local: _localController.text,
+      total: double.tryParse(_totalController.text.replaceAll(',', '.')) ??
+          widget.gasto.total,
+      categoriaId: _categoriaId ?? widget.gasto.categoriaId,
+    );
+    await context.read<GastoViewModel>().atualizarGasto(atualizado);
+    await context.read<ExtratoViewModel>().carregarGastos();
+    if (mounted) Navigator.pop(context);
+  }
+
+  Future<void> _deletar() async {
+    final confirmar = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Excluir gasto'),
+        content: const Text('Tem certeza que deseja excluir este gasto?'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancelar')),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Excluir')),
+        ],
+      ),
+    );
+    if (confirmar == true) {
+      final id = widget.gasto.id;
+      if (id != null) {
+        await context.read<GastoViewModel>().deletarGasto(id);
+        await context.read<ExtratoViewModel>().carregarGastos();
+      }
+      if (mounted) Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categorias = context.watch<CategoriaViewModel>().categorias;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Detalhes do Gasto')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Text('Data: '),
+                const SizedBox(width: 8),
+                TextButton(
+                  onPressed: _selecionarData,
+                  child: Text(DateFormat('dd/MM/yyyy').format(_data)),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<int>(
+              value: _categoriaId,
+              decoration: const InputDecoration(labelText: 'Categoria'),
+              items: categorias
+                  .map((c) => DropdownMenuItem(value: c.id, child: Text(c.titulo)))
+                  .toList(),
+              onChanged: (v) => setState(() => _categoriaId = v),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _totalController,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              decoration: const InputDecoration(labelText: 'Total R\$'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _localController,
+              decoration: const InputDecoration(labelText: 'Local'),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(onPressed: _salvar, child: const Text('Salvar')),
+                ElevatedButton(
+                  onPressed: _deletar,
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                  child: const Text('Excluir'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -36,6 +36,16 @@ class GastoViewModel extends ChangeNotifier {
     return _repo.create(gasto);
   }
 
+  Future<void> atualizarGasto(Gasto gasto) async {
+    await _repo.update(gasto);
+    notifyListeners();
+  }
+
+  Future<void> deletarGasto(int id) async {
+    await _repo.delete(id);
+    notifyListeners();
+  }
+
   Future<List<Gasto>> listarGastos() => _repo.findAll();
 
   Future<bool> _processar(String entrada, GastoInputStrategy estrategia) async {


### PR DESCRIPTION
## Summary
- add `GastoDetalheView` for editing or deleting an expense
- open detail screen from `ExtratoView` using DataTable row selection
- support update/delete in `GastoViewModel`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b37667483319928bb25b9e253ae