### PR TITLE
Update pubspec versions and enable linux build

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,24 +31,24 @@ dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: any
-  crypto: any
-  flutter_secure_storage: any
-  provider: any
-  sqflite:
-  sqflite_common_ffi: any
-  sqlite3_flutter_libs: any
+  cupertino_icons: ^1.0.8
+  crypto: ^3.0.6
+  flutter_secure_storage: ^9.2.4
+  provider: ^6.1.5
+  sqflite: ^2.4.2
+  sqflite_common_ffi: ^2.3.6
+  sqlite3_flutter_libs: ^0.5.34
   expenses_control:
     path: framework
-  html: 
-  http: 
-  fl_chart: 
-  intl: 
-  mobile_scanner: 
-  url_launcher: 
-  flutter_dotenv: 
-  collection: 
-  month_picker_dialog: 
+  html: ^0.15.6
+  http: ^1.4.0
+  fl_chart: ^1.0.0
+  intl: ^0.20.2
+  mobile_scanner: ^7.0.1
+  url_launcher: ^6.3.1
+  flutter_dotenv: ^5.2.1
+  collection: ^1.19.1
+  month_picker_dialog: ^6.2.3
 
 dev_dependencies:
   flutter_test:
@@ -59,7 +59,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: 
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- pin explicit dependency versions in `pubspec.yaml`
- verify that the project builds for Linux by creating `.env` and running `flutter build linux`

## Testing
- `flutter pub get`
- `CI=true flutter build linux --release`

------
https://chatgpt.com/codex/tasks/task_e_6872b519d77c8331b119acd7751be8b7