### PR TITLE
Add receipt image parsing via Gemini

### DIFF
--- a/lib/models/strategies/image_input_strategy.dart
+++ b/lib/models/strategies/image_input_strategy.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+import '../services/gemini_service.dart';
+import 'gasto_input_strategy.dart';
+
+class ImageInputStrategy implements GastoInputStrategy {
+  final GeminiService _geminiService;
+  final List<String> _categorias;
+
+  ImageInputStrategy({required GeminiService geminiService, List<String> categorias = const []})
+      : _geminiService = geminiService,
+        _categorias = categorias;
+
+  @override
+  Future<Map<String, dynamic>> process(String input) async {
+    final bytes = await File(input).readAsBytes();
+    return _geminiService.parseExpenseFromImage(bytes, categorias: _categorias);
+  }
+}

--- a/lib/view/adicionar_gasto_view.dart
+++ b/lib/view/adicionar_gasto_view.dart
@@ -2,8 +2,9 @@ import 'package:expenses_control_app/view/gasto_view.dart';
 import 'package:expenses_control_app/view/gemini_text_view.dart';
 import 'package:expenses_control_app/view_model/gasto_view_model.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile_scanner/mobile_scanner.dart'; // Importe o novo pacote
+import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:provider/provider.dart';
+import 'package:image_picker/image_picker.dart';
 
 class AdicionarGastoView extends StatefulWidget {
   @override
@@ -63,6 +64,26 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
           });
         }
       }
+    }
+  }
+
+  Future<void> _tirarFoto() async {
+    final picker = ImagePicker();
+    final foto = await picker.pickImage(source: ImageSource.camera);
+    if (foto == null) return;
+    final vm = context.read<GastoViewModel>();
+    final sucesso = await vm.processarImagem(foto.path);
+    if (!mounted) return;
+    if (sucesso) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+            builder: (context) => GastoView(dadosIniciais: vm.scrapedData)),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(vm.errorMessage ?? 'Erro desconhecido')),
+      );
     }
   }
 
@@ -144,8 +165,23 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
                       ),
+                  ),
+                  label: Text('Inserir por Texto', style: TextStyle(fontSize: 18)),
+                  ),
+                  SizedBox(height: 12),
+                  // Botão de Inserção via foto
+                  OutlinedButton.icon(
+                    icon: Icon(Icons.photo_camera),
+                    onPressed: _tirarFoto,
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(color: Colors.orange, width: 1.5),
+                      foregroundColor: Colors.orange,
+                      padding: EdgeInsets.symmetric(horizontal: 40, vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
-                    label: Text('Inserir por Texto', style: TextStyle(fontSize: 18)),
+                    label: Text('Inserir por Foto', style: TextStyle(fontSize: 18)),
                   ),
                   SizedBox(height: 12),
                   // Botão de Inserção Manual

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../models/strategies/gasto_input_strategy.dart';
 import '../models/strategies/qr_code_input_strategy.dart';
 import '../models/strategies/text_input_strategy.dart';
+import '../models/strategies/image_input_strategy.dart';
 
 class GastoViewModel extends ChangeNotifier {
   final WebScrapingService _webScrapingService;
@@ -87,5 +88,13 @@ class GastoViewModel extends ChangeNotifier {
     final estrategia = QrCodeInputStrategy(
         scrapingService: _webScrapingService, categorias: nomesCategorias);
     return _processar(url, estrategia);
+  }
+
+  Future<bool> processarImagem(String caminho) async {
+    final cats = await _categoriaRepo.findAll();
+    final nomesCategorias = cats.map((c) => c.titulo).toList();
+    final estrategia = ImageInputStrategy(
+        geminiService: _geminiService, categorias: nomesCategorias);
+    return _processar(caminho, estrategia);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,8 +44,9 @@ dependencies:
   http: 
   fl_chart: 
   intl: 
-  mobile_scanner: 
-  url_launcher: 
+  mobile_scanner:
+  image_picker:
+  url_launcher:
   flutter_dotenv: 
   collection: 
   month_picker_dialog: 


### PR DESCRIPTION
## Summary
- integrate Gemini to parse receipt images
- add ImageInputStrategy
- support receipt photos in GastoViewModel
- enable photo capture on add expense screen
- include image_picker dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b9ab46848331ad6bd10e16b2a0f8