### PR TITLE
Improve QR code fallback with WebView

### DIFF
--- a/lib/models/services/web_scrapping_service.dart
+++ b/lib/models/services/web_scrapping_service.dart
@@ -48,6 +48,20 @@ class WebScrapingService {
     }
   }
 
+  /// Analisa o HTML de uma NFC-e já carregado no navegador.
+  Future<Map<String, dynamic>> parseNfceHtml(String html,
+      {List<String> categorias = const []}) async {
+    try {
+      final data = _parseNfceHtmlDart(html);
+      if (data['itens'] == null || (data['itens'] as List).isEmpty) {
+        return await _gemini.parseExpenseFromHtml(html, categorias: categorias);
+      }
+      return data;
+    } catch (_) {
+      return await _gemini.parseExpenseFromHtml(html, categorias: categorias);
+    }
+  }
+
   /// Analisa o conteúdo HTML de uma NFC-e e extrai os dados.
   Map<String, dynamic> _parseNfceHtmlDart(String htmlContent) {
     final document = parse(htmlContent);

--- a/lib/models/strategies/html_input_strategy.dart
+++ b/lib/models/strategies/html_input_strategy.dart
@@ -1,0 +1,16 @@
+import '../services/web_scrapping_service.dart';
+import 'gasto_input_strategy.dart';
+
+class HtmlInputStrategy implements GastoInputStrategy {
+  final WebScrapingService _scrapingService;
+  final List<String> _categorias;
+
+  HtmlInputStrategy({required WebScrapingService scrapingService, List<String> categorias = const []})
+      : _scrapingService = scrapingService,
+        _categorias = categorias;
+
+  @override
+  Future<Map<String, dynamic>> process(String input) {
+    return _scrapingService.parseNfceHtml(input, categorias: _categorias);
+  }
+}

--- a/lib/view/adicionar_gasto_view.dart
+++ b/lib/view/adicionar_gasto_view.dart
@@ -1,5 +1,6 @@
 import 'package:expenses_control_app/view/gasto_view.dart';
 import 'package:expenses_control_app/view/gemini_text_view.dart';
+import 'package:expenses_control_app/view/nfce_webview.dart';
 import 'package:expenses_control_app/view_model/gasto_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -38,31 +39,36 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
       final success = await viewModel.processarQRCode(code);
 
       if (success && mounted) {
-        // Navega para a tela de gasto com os dados
         Navigator.push(
           context,
           MaterialPageRoute(
             builder: (context) => GastoView(dadosIniciais: viewModel.scrapedData),
           ),
         ).then((_) {
-          // Quando voltar da tela de cadastro, reinicia o processamento
-          if(mounted) {
+          if (mounted) {
             setState(() {
               _isProcessing = false;
             });
           }
         });
-      } else {
-        // Se falhar, exibe o erro
+      } else if (mounted && code.startsWith('https://')) {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => NfceWebView(url: code)),
+        );
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(viewModel.errorMessage ?? 'Ocorreu um erro desconhecido.')),
-          );
-          await Future.delayed(const Duration(seconds: 3)); // Delay para o usuário ler o erro
           setState(() {
-            _isProcessing = false; // Permite nova tentativa
+            _isProcessing = false;
           });
         }
+      } else if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(viewModel.errorMessage ?? 'Ocorreu um erro desconhecido.')),
+        );
+        await Future.delayed(const Duration(seconds: 3));
+        setState(() {
+          _isProcessing = false;
+        });
       }
     }
   }

--- a/lib/view/nfce_webview.dart
+++ b/lib/view/nfce_webview.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:provider/provider.dart';
+import '../view_model/gasto_view_model.dart';
+import 'gasto_view.dart';
+
+class NfceWebView extends StatefulWidget {
+  final String url;
+  const NfceWebView({super.key, required this.url});
+
+  @override
+  State<NfceWebView> createState() => _NfceWebViewState();
+}
+
+class _NfceWebViewState extends State<NfceWebView> {
+  late final WebViewController _controller;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (url) {
+          setState(() {
+            _loading = false;
+          });
+        }),
+      )
+      ..loadRequest(Uri.parse(widget.url));
+  }
+
+  Future<void> _importar() async {
+    final encodedHtml = await _controller.runJavaScriptReturningResult(
+        "JSON.stringify(document.documentElement.outerHTML)");
+    final html = jsonDecode(encodedHtml as String) as String;
+    final vm = context.read<GastoViewModel>();
+    final ok = await vm.processarHtml(html);
+    if (!mounted) return;
+    if (ok) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+            builder: (context) => GastoView(dadosIniciais: vm.scrapedData)),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(vm.errorMessage ?? 'Erro ao processar nota')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Nota Fiscal'),
+        actions: [
+          IconButton(onPressed: _importar, icon: const Icon(Icons.check)),
+        ],
+      ),
+      body: Stack(
+        children: [
+          WebViewWidget(controller: _controller),
+          if (_loading)
+            const Center(
+              child: CircularProgressIndicator(),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view_model/gasto_view_model.dart
+++ b/lib/view_model/gasto_view_model.dart
@@ -8,6 +8,7 @@ import '../models/strategies/gasto_input_strategy.dart';
 import '../models/strategies/qr_code_input_strategy.dart';
 import '../models/strategies/text_input_strategy.dart';
 import '../models/strategies/image_input_strategy.dart';
+import '../models/strategies/html_input_strategy.dart';
 
 class GastoViewModel extends ChangeNotifier {
   final WebScrapingService _webScrapingService;
@@ -88,6 +89,14 @@ class GastoViewModel extends ChangeNotifier {
     final estrategia = QrCodeInputStrategy(
         scrapingService: _webScrapingService, categorias: nomesCategorias);
     return _processar(url, estrategia);
+  }
+
+  Future<bool> processarHtml(String html) async {
+    final cats = await _categoriaRepo.findAll();
+    final nomesCategorias = cats.map((c) => c.titulo).toList();
+    final estrategia = HtmlInputStrategy(
+        scrapingService: _webScrapingService, categorias: nomesCategorias);
+    return _processar(html, estrategia);
   }
 
   Future<bool> processarImagem(String caminho) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,9 +47,10 @@ dependencies:
   mobile_scanner:
   image_picker:
   url_launcher:
-  flutter_dotenv: 
-  collection: 
-  month_picker_dialog: 
+  flutter_dotenv:
+  collection:
+  month_picker_dialog:
+  webview_flutter:
 
 dev_dependencies:
   flutter_test:

--- a/test/web_scraping_service_test.dart
+++ b/test/web_scraping_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:expenses_control_app/models/services/web_scrapping_service.dart';
 import 'package:expenses_control_app/models/services/gemini_service.dart';
@@ -26,6 +27,17 @@ void main() {
       ignoreBadCertificate: true,
     );
 
+    expect(data, isA<Map<String, dynamic>>());
+    expect(data, contains('estabelecimento'));
+    expect(data, contains('itens'));
+    expect(data, contains('compra'));
+  });
+
+  test('parse NFCe HTML string', () async {
+    final scrapingService =
+        WebScrapingService(geminiService: FakeGeminiService());
+    final html = await File('assets/Consulta DF-e.html').readAsString();
+    final data = await scrapingService.parseNfceHtml(html);
     expect(data, isA<Map<String, dynamic>>());
     expect(data, contains('estabelecimento'));
     expect(data, contains('itens'));


### PR DESCRIPTION
## Summary
- add `webview_flutter` dependency
- allow parsing HTML directly from WebView
- implement `NfceWebView` screen to load nota fiscal URL
- handle WebView fallback in `AdicionarGastoView`
- support parsing HTML via `HtmlInputStrategy`
- test HTML parsing

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: package not found)*
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876bdcc84d8833191a81c43192bfa3b