### PR TITLE
Add open in browser option for NFCe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ Quando a leitura direta da NFC-e pelo scraper falha, o aplicativo envia o
 HTML obtido da nota fiscal para o Gemini, que extrai os dados no mesmo formato
 JSON. Assim ainda é possível preencher a tela mesmo que o layout do site mude.
 
+### Abrir nota no navegador
+
+Se preferir verificar a página original da NFC-e ao escanear o QR Code, toque
+no ícone de abrir no navegador que aparece na tela da nota. O aplicativo
+tentará abrir a URL no navegador padrão do dispositivo.
+

--- a/lib/view/nfce_webview.dart
+++ b/lib/view/nfce_webview.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../view_model/gasto_view_model.dart';
 import 'gasto_view.dart';
 
@@ -52,12 +53,25 @@ class _NfceWebViewState extends State<NfceWebView> {
     }
   }
 
+  Future<void> _abrirNoNavegador() async {
+    final uri = Uri.parse(widget.url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Não foi possível abrir o navegador.')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Nota Fiscal'),
         actions: [
+          IconButton(onPressed: _abrirNoNavegador, icon: const Icon(Icons.open_in_browser)),
           IconButton(onPressed: _importar, icon: const Icon(Icons.check)),
         ],
       ),


### PR DESCRIPTION
## Summary
- add ability to open NFCe page in the system browser
- document how to open the page manually

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c62868808331b14a531cc3c1ecae