### PR TITLE
Add editable categoria cache management

### DIFF
--- a/framework/lib/models/gasto.dart
+++ b/framework/lib/models/gasto.dart
@@ -10,6 +10,7 @@ class Gasto extends BaseUserEntity {
   final DateTime data;
   final int categoriaId;
   final String local;
+  final String descricaoNormalizada;
 
   // Not persisted in the same “gastos” table. You’ll likely store produtos
   // in a separate table and join later, but we keep the field here for domain
@@ -26,6 +27,7 @@ class Gasto extends BaseUserEntity {
     required this.data,
     required this.categoriaId,
     required this.local,
+    this.descricaoNormalizada = '',
     this.produtos = const [],
   });
 
@@ -39,6 +41,7 @@ class Gasto extends BaseUserEntity {
     DateTime? data,
     int? categoriaId,
     String? local,
+    String? descricaoNormalizada,
     List<Produto>? produtos,
   }) =>
       Gasto(
@@ -48,6 +51,8 @@ class Gasto extends BaseUserEntity {
         data: data ?? this.data,
         categoriaId: categoriaId ?? this.categoriaId,
         local: local ?? this.local,
+        descricaoNormalizada:
+            descricaoNormalizada ?? this.descricaoNormalizada,
         produtos: produtos ?? this.produtos,
       );
 
@@ -63,6 +68,7 @@ class Gasto extends BaseUserEntity {
         'data': data.toIso8601String(),
         'categoria_id': categoriaId,
         'local': local,
+        'descricao_normalizada': descricaoNormalizada,
         'usuario_id': usuarioId,
       };
 
@@ -86,6 +92,7 @@ class Gasto extends BaseUserEntity {
           : DateTime.now(),
       categoriaId: map['categoria_id'] as int? ?? 0,
       local: map['local'] as String? ?? '',
+      descricaoNormalizada: map['descricao_normalizada'] as String? ?? '',
     );
   }
 

--- a/lib/models/categoria_cache.dart
+++ b/lib/models/categoria_cache.dart
@@ -1,0 +1,62 @@
+import 'package:expenses_control/models/base/base_user_entity.dart';
+
+class CategoriaCache extends BaseUserEntity {
+  final String descricaoOriginal;
+  final String descricaoNormalizada;
+  final int categoriaId;
+
+  CategoriaCache({
+    super.id,
+    required super.usuarioId,
+    required this.descricaoOriginal,
+    required this.descricaoNormalizada,
+    required this.categoriaId,
+  });
+
+  CategoriaCache copyWith({
+    int? id,
+    int? usuarioId,
+    String? descricaoOriginal,
+    String? descricaoNormalizada,
+    int? categoriaId,
+  }) {
+    return CategoriaCache(
+      id: id ?? this.id,
+      usuarioId: usuarioId ?? this.usuarioId,
+      descricaoOriginal: descricaoOriginal ?? this.descricaoOriginal,
+      descricaoNormalizada: descricaoNormalizada ?? this.descricaoNormalizada,
+      categoriaId: categoriaId ?? this.categoriaId,
+    );
+  }
+
+  @override
+  String get tableName => 'categoria_cache';
+
+  @override
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'descricao_original': descricaoOriginal,
+        'descricao_normalizada': descricaoNormalizada,
+        'categoria_id': categoriaId,
+        'usuario_id': usuarioId,
+      };
+
+  factory CategoriaCache.fromMap(Map<String, dynamic> map) {
+    if (map.isEmpty) {
+      return CategoriaCache(
+        usuarioId: 0,
+        descricaoOriginal: '',
+        descricaoNormalizada: '',
+        categoriaId: 0,
+      );
+    }
+
+    return CategoriaCache(
+      id: map['id'] as int?,
+      usuarioId: (map['usuario_id'] as int?) ?? 0,
+      descricaoOriginal: map['descricao_original'] as String? ?? '',
+      descricaoNormalizada: map['descricao_normalizada'] as String? ?? '',
+      categoriaId: map['categoria_id'] as int? ?? 0,
+    );
+  }
+}

--- a/lib/models/data/categoria_cache_repository.dart
+++ b/lib/models/data/categoria_cache_repository.dart
@@ -1,0 +1,95 @@
+import 'package:expenses_control/models/base/base_repository.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../categoria_cache.dart';
+import '../../utils/string_normalizer.dart';
+
+class CategoriaCacheRepository extends BaseRepository<CategoriaCache> {
+  CategoriaCacheRepository(Database db)
+      : super(database: db, fromMap: CategoriaCache.fromMap);
+
+  Future<CategoriaCache?> findByDescricao(
+      String descricao, int usuarioId) async {
+    final normalizada = normalizeText(descricao);
+    final rows = await db.query(
+      'categoria_cache',
+      where: 'descricao_normalizada = ? AND usuario_id = ?',
+      whereArgs: [normalizada, usuarioId],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return CategoriaCache.fromMap(rows.first);
+  }
+
+  Future<List<CategoriaCache>> findAllByUsuario(int usuarioId) async {
+    final rows = await db.query(
+      'categoria_cache',
+      where: 'usuario_id = ?',
+      whereArgs: [usuarioId],
+      orderBy: 'descricao_original COLLATE NOCASE',
+    );
+    return rows.map(CategoriaCache.fromMap).toList();
+  }
+
+  Future<void> atualizarCategoria(int cacheId, int categoriaId) async {
+    await db.update(
+      'categoria_cache',
+      {'categoria_id': categoriaId},
+      where: 'id = ?',
+      whereArgs: [cacheId],
+    );
+  }
+
+  Future<int> aplicarCategoriaParaDescricao({
+    required int usuarioId,
+    required String descricaoNormalizada,
+    required int categoriaId,
+  }) {
+    final alvo = normalizeText(descricaoNormalizada);
+    return db.update(
+      'gastos',
+      {'categoria_id': categoriaId},
+      where: 'usuario_id = ? AND descricao_normalizada = ?',
+      whereArgs: [usuarioId, alvo],
+    );
+  }
+
+  Future<void> garantirDescricoesNormalizadas(int usuarioId) async {
+    final rows = await db.query(
+      'gastos',
+      columns: ['id', 'local', 'descricao_normalizada'],
+      where: 'usuario_id = ?',
+      whereArgs: [usuarioId],
+    );
+    if (rows.isEmpty) return;
+
+    final caches = await findAllByUsuario(usuarioId);
+    final batch = db.batch();
+    for (final row in rows) {
+      final atual = row['descricao_normalizada'] as String?;
+      if (atual == null || atual.isEmpty) {
+        final local = row['local'] as String? ?? '';
+        final normalizadoLocal = normalizeText(local);
+        String novoValor = normalizadoLocal;
+        for (final cache in caches) {
+          final cacheDesc = cache.descricaoNormalizada;
+          if (cacheDesc == normalizadoLocal) {
+            novoValor = cacheDesc;
+            break;
+          }
+          if (cacheDesc.contains(normalizadoLocal) ||
+              normalizadoLocal.contains(cacheDesc)) {
+            novoValor = cacheDesc;
+          }
+        }
+        batch.update(
+          'gastos',
+          {'descricao_normalizada': novoValor},
+          where: 'id = ?',
+          whereArgs: [row['id']],
+        );
+      }
+    }
+    await batch.commit(noResult: true);
+  }
+}

--- a/lib/models/services/extrato_import_service.dart
+++ b/lib/models/services/extrato_import_service.dart
@@ -1,0 +1,250 @@
+import 'package:expenses_control/models/categoria.dart';
+import 'package:expenses_control/models/data/gasto_repository.dart';
+import 'package:expenses_control/models/gasto.dart';
+import 'package:intl/intl.dart';
+
+import '../../utils/string_normalizer.dart';
+import '../categoria_cache.dart';
+import '../data/categoria_cache_repository.dart';
+import '../data/categoria_repository.dart';
+import 'gemini_service.dart';
+
+class ExtratoImportService {
+  final GastoRepository _gastoRepository;
+  final CategoriaRepository _categoriaRepository;
+  final CategoriaCacheRepository _cacheRepository;
+  final GeminiService _geminiService;
+
+  ExtratoImportService({
+    required GastoRepository gastoRepository,
+    required CategoriaRepository categoriaRepository,
+    required CategoriaCacheRepository cacheRepository,
+    required GeminiService geminiService,
+  })  : _gastoRepository = gastoRepository,
+        _categoriaRepository = categoriaRepository,
+        _cacheRepository = cacheRepository,
+        _geminiService = geminiService;
+
+  Future<int> importarExtrato(String conteudo, int usuarioId) async {
+    final linhas = conteudo.trim();
+    if (linhas.isEmpty) {
+      throw Exception('O extrato está vazio.');
+    }
+
+    final categorias = await _categoriaRepository.findAll();
+    if (categorias.isEmpty) {
+      throw Exception('Nenhuma categoria cadastrada para o usuário.');
+    }
+
+    final registros = _detectarParser(linhas);
+    if (registros == null) {
+      throw Exception('Formato de extrato não reconhecido.');
+    }
+
+    final itens = registros(linhas);
+    if (itens.isEmpty) {
+      throw Exception('Nenhum lançamento encontrado no extrato informado.');
+    }
+
+    int importados = 0;
+    for (final item in itens) {
+      if (item.valor <= 0) continue;
+      final descricao = item.descricao;
+      final descricaoNormalizada = normalizeText(descricao);
+      final categoriaId = await _obterCategoriaId(
+        descricao,
+        categorias,
+        usuarioId,
+        valor: item.valor,
+        data: item.data,
+        tipo: item.tipo,
+      );
+      final gasto = Gasto(
+        usuarioId: usuarioId,
+        categoriaId: categoriaId,
+        total: item.valor,
+        data: item.data,
+        local: item.local,
+        descricaoNormalizada: descricaoNormalizada,
+      );
+      await _gastoRepository.create(gasto);
+      importados++;
+    }
+    return importados;
+  }
+
+  Future<int> _obterCategoriaId(
+    String descricao,
+    List<Categoria> categorias,
+    int usuarioId, {
+    double? valor,
+    DateTime? data,
+    String? tipo,
+  }) async {
+    final cache = await _cacheRepository.findByDescricao(descricao, usuarioId);
+    if (cache != null) {
+      return cache.categoriaId;
+    }
+
+    final nomesCategorias = categorias.map((c) => c.titulo).toList();
+    String resposta;
+    try {
+      resposta = await _geminiService.classificarTransacao(
+        descricao: descricao,
+        categorias: nomesCategorias,
+        valor: valor,
+        data: data,
+        tipo: tipo,
+      );
+    } catch (_) {
+      resposta = categorias.first.titulo;
+    }
+
+    final categoria = _matchCategoria(resposta, categorias);
+    final fallback = categorias.firstWhere(
+      (c) => c.id != null,
+      orElse: () => categorias.first,
+    );
+    final categoriaEscolhida = categoria.id != null ? categoria : fallback;
+    final normalizada = normalizeText(descricao);
+
+    await _cacheRepository.create(
+      CategoriaCache(
+        usuarioId: usuarioId,
+        descricaoOriginal: descricao,
+        descricaoNormalizada: normalizada,
+        categoriaId: categoriaEscolhida.id ?? fallback.id ?? 0,
+      ),
+    );
+
+    return categoriaEscolhida.id ?? fallback.id ?? 0;
+  }
+
+  Categoria _matchCategoria(String resposta, List<Categoria> categorias) {
+    final alvo = normalizeText(resposta);
+    for (final categoria in categorias) {
+      if (normalizeText(categoria.titulo) == alvo) {
+        return categoria;
+      }
+    }
+    for (final categoria in categorias) {
+      if (alvo.contains(normalizeText(categoria.titulo)) ||
+          normalizeText(categoria.titulo).contains(alvo)) {
+        return categoria;
+      }
+    }
+    return categorias.first;
+  }
+
+  List<_ExtratoItem> Function(String)? _detectarParser(String conteudo) {
+    if (conteudo.contains('Extrato Conta Corrente')) {
+      return _parseContaCorrente;
+    }
+    if (conteudo.contains('"Data","Lançamento"')) {
+      return _parseCartao;
+    }
+    return null;
+  }
+
+  List<_ExtratoItem> _parseContaCorrente(String conteudo) {
+    final linhas = conteudo.replaceAll('\r', '').split('\n');
+    final inicio =
+        linhas.indexWhere((l) => l.trim().startsWith('Data Lançamento'));
+    if (inicio == -1) return [];
+    final dataFormat = DateFormat('dd/MM/yyyy');
+    final itens = <_ExtratoItem>[];
+    for (var i = inicio + 1; i < linhas.length; i++) {
+      final linha = linhas[i].trim();
+      if (linha.isEmpty) continue;
+      final partes = linha.split(';');
+      if (partes.length < 4) continue;
+      try {
+        final data = dataFormat.parse(partes[0].trim());
+        final historico = partes[1].trim();
+        final descricao = partes.length > 2 ? partes[2].trim() : '';
+        final valorBruto = partes[3].trim();
+        final valor = _parseValor(valorBruto).abs();
+        final texto = [historico, descricao].where((p) => p.isNotEmpty).join(' - ');
+        itens.add(
+          _ExtratoItem(
+            data: data,
+            descricao: texto.isEmpty ? historico : texto,
+            local: descricao.isEmpty ? historico : descricao,
+            valor: valor,
+            tipo: historico,
+          ),
+        );
+      } catch (_) {
+        continue;
+      }
+    }
+    return itens;
+  }
+
+  List<_ExtratoItem> _parseCartao(String conteudo) {
+    final linhas = conteudo.replaceAll('\r', '').split('\n');
+    if (linhas.length <= 1) return [];
+    final dataFormat = DateFormat('dd/MM/yyyy');
+    final itens = <_ExtratoItem>[];
+    for (var i = 1; i < linhas.length; i++) {
+      var linha = linhas[i].trim();
+      if (linha.isEmpty) continue;
+      if (linha.startsWith('"')) {
+        linha = linha.substring(1);
+      }
+      if (linha.endsWith('"')) {
+        linha = linha.substring(0, linha.length - 1);
+      }
+      final partes = linha.split('","');
+      if (partes.length < 5) continue;
+      try {
+        final data = dataFormat.parse(partes[0].trim());
+        final lancamento = partes[1].trim();
+        final tipo = partes[3].trim();
+        final valorBruto = partes[4].trim();
+        final valor = _parseValor(valorBruto);
+        final categoriaInformada = partes[2].trim();
+        final descricao =
+            '$lancamento ($categoriaInformada) - $tipo'.replaceAll(RegExp(r'\s+'), ' ').trim();
+        itens.add(
+          _ExtratoItem(
+            data: data,
+            descricao: descricao,
+            local: lancamento,
+            valor: valor.abs(),
+            tipo: tipo.isEmpty ? categoriaInformada : tipo,
+          ),
+        );
+      } catch (_) {
+        continue;
+      }
+    }
+    return itens;
+  }
+
+  double _parseValor(String valor) {
+    final cleaned = valor
+        .replaceAll('R\$', '')
+        .replaceAll('.', '')
+        .replaceAll(' ', '')
+        .replaceAll(',', '.')
+        .trim();
+    return double.tryParse(cleaned) ?? 0;
+  }
+}
+
+class _ExtratoItem {
+  final DateTime data;
+  final String descricao;
+  final String local;
+  final double valor;
+  final String? tipo;
+
+  _ExtratoItem({
+    required this.data,
+    required this.descricao,
+    required this.local,
+    required this.valor,
+    this.tipo,
+  });
+}

--- a/lib/models/services/gemini_service.dart
+++ b/lib/models/services/gemini_service.dart
@@ -223,6 +223,44 @@ Considere que hoje é $hoje e utilize esta data caso nenhuma outra seja informad
     }
   }
 
+  Future<String> classificarTransacao({
+    required String descricao,
+    required List<String> categorias,
+    double? valor,
+    DateTime? data,
+    String? tipo,
+  }) async {
+    if (categorias.isEmpty) {
+      throw Exception('Nenhuma categoria disponível para classificação.');
+    }
+
+    if (apiKey.isEmpty) {
+      return categorias.first;
+    }
+
+    final buffer = StringBuffer()
+      ..writeln('Descrição: $descricao');
+    if (valor != null) {
+      buffer.writeln('Valor: ${valor.toStringAsFixed(2)}');
+    }
+    if (tipo != null && tipo.isNotEmpty) {
+      buffer.writeln('Tipo: $tipo');
+    }
+    if (data != null) {
+      buffer.writeln('Data: ${DateFormat('dd/MM/yyyy').format(data)}');
+    }
+
+    final prompt = '''Selecione a categoria mais adequada para a transação a seguir.
+Considere apenas as categorias listadas a seguir e retorne exatamente o nome de uma delas, sem texto adicional.
+Categorias: ${categorias.join(', ')}
+
+${buffer.toString()}''';
+
+    final resposta = await _generateText(prompt);
+    final primeiraLinha = resposta.split(RegExp(r'[\r\n]')).first.trim();
+    return primeiraLinha.isEmpty ? categorias.first : primeiraLinha;
+  }
+
   Future<String> sugestaoParaMeta(
       String descricao, double gastoAtual, double limite) async {
     final prompt =

--- a/lib/utils/string_normalizer.dart
+++ b/lib/utils/string_normalizer.dart
@@ -1,0 +1,67 @@
+String normalizeText(String input) {
+  const map = {
+    'á': 'a',
+    'à': 'a',
+    'â': 'a',
+    'ã': 'a',
+    'ä': 'a',
+    'é': 'e',
+    'è': 'e',
+    'ê': 'e',
+    'ë': 'e',
+    'í': 'i',
+    'ì': 'i',
+    'î': 'i',
+    'ï': 'i',
+    'ó': 'o',
+    'ò': 'o',
+    'ô': 'o',
+    'õ': 'o',
+    'ö': 'o',
+    'ú': 'u',
+    'ù': 'u',
+    'û': 'u',
+    'ü': 'u',
+    'ç': 'c',
+    'Á': 'a',
+    'À': 'a',
+    'Â': 'a',
+    'Ã': 'a',
+    'Ä': 'a',
+    'É': 'e',
+    'È': 'e',
+    'Ê': 'e',
+    'Ë': 'e',
+    'Í': 'i',
+    'Ì': 'i',
+    'Î': 'i',
+    'Ï': 'i',
+    'Ó': 'o',
+    'Ò': 'o',
+    'Ô': 'o',
+    'Õ': 'o',
+    'Ö': 'o',
+    'Ú': 'u',
+    'Ù': 'u',
+    'Û': 'u',
+    'Ü': 'u',
+    'Ç': 'c',
+  };
+
+  final buffer = StringBuffer();
+  for (final rune in input.runes) {
+    final char = String.fromCharCode(rune);
+    final mapped = map[char] ?? char.toLowerCase();
+    if (RegExp(r'[a-z0-9 ]').hasMatch(mapped)) {
+      buffer.write(mapped);
+    } else if (mapped.trim().isEmpty) {
+      buffer.write(' ');
+    } else {
+      buffer.write(mapped);
+    }
+  }
+
+  final normalized =
+      buffer.toString().toLowerCase().replaceAll(RegExp(r'[^a-z0-9 ]'), ' ');
+  return normalized.replaceAll(RegExp(r'\s+'), ' ').trim();
+}

--- a/lib/view/adicionar_gasto_view.dart
+++ b/lib/view/adicionar_gasto_view.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:image_picker/image_picker.dart';
 import '../view_model/usuario_view_model.dart';
 import 'package:expenses_control/models/usuario.dart';
+import 'extrato_import_view.dart';
 
 class AdicionarGastoView extends StatefulWidget {
   @override
@@ -188,6 +189,29 @@ class _AdicionarGastoViewState extends State<AdicionarGastoView> {
                     ),
                     label: Text('Inserir por Texto',
                         style: const TextStyle(fontSize: 18)),
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.receipt_long),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const ExtratoImportView(),
+                        ),
+                      );
+                    },
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: Colors.blueGrey, width: 1.5),
+                      foregroundColor: Colors.blueGrey,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 40, vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    label: const Text('Importar Extrato',
+                        style: TextStyle(fontSize: 18)),
                   ),
                   const SizedBox(height: 12),
                   if (isGold) ...[

--- a/lib/view/categoria_cache_view.dart
+++ b/lib/view/categoria_cache_view.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../view_model/categoria_cache_view_model.dart';
+import '../view_model/extrato_view_model.dart';
+import '../view_model/usuario_view_model.dart';
+
+class CategoriaCacheView extends StatefulWidget {
+  const CategoriaCacheView({super.key});
+
+  @override
+  State<CategoriaCacheView> createState() => _CategoriaCacheViewState();
+}
+
+class _CategoriaCacheViewState extends State<CategoriaCacheView> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      final usuarioId =
+          context.read<UsuarioViewModel>().usuarioLogado?.id ?? 0;
+      context.read<CategoriaCacheViewModel>().carregar(usuarioId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<CategoriaCacheViewModel>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ajustar categorias sugeridas'),
+      ),
+      body: vm.loading
+          ? const Center(child: CircularProgressIndicator())
+          : _buildContent(context, vm),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, CategoriaCacheViewModel vm) {
+    if (vm.error != null) {
+      return Center(child: Text(vm.error!));
+    }
+    if (vm.caches.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Nenhum mapeamento salvo até o momento. '
+            'Importe um extrato para que as sugestões apareçam aqui.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final categorias = vm.categorias;
+    if (categorias.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Cadastre categorias antes de ajustar os mapeamentos.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemBuilder: (context, index) {
+        final cache = vm.caches[index];
+        final possuiCategoria = categorias.any((c) => c.id == cache.categoriaId);
+        final fallbackId = categorias.first.id ?? cache.categoriaId;
+        final valorSelecionado =
+            possuiCategoria ? cache.categoriaId : fallbackId;
+        final categoriaAtual =
+            vm.obterCategoriaPorId(valorSelecionado)?.titulo ?? 'Sem categoria';
+        return Card(
+          child: ListTile(
+            title: Text(cache.descricaoOriginal),
+            subtitle: Text('Categoria atual: $categoriaAtual'),
+            trailing: DropdownButton<int>(
+              value: valorSelecionado,
+              items: categorias
+                  .map(
+                    (c) => DropdownMenuItem<int>(
+                      value: c.id,
+                      child: Text(c.titulo),
+                    ),
+                  )
+                  .toList(),
+              onChanged: vm.estaAtualizando(cache.id)
+                  ? null
+                  : (value) async {
+                      if (value == null) return;
+                      final scaffold = ScaffoldMessenger.of(context);
+                      try {
+                        final afetados = await vm.atualizarCategoria(
+                          cache.copyWith(categoriaId: valorSelecionado),
+                          value,
+                        );
+                        if (!mounted) return;
+                        scaffold.showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              afetados > 0
+                                  ? 'Categoria atualizada em $afetados lançamentos.'
+                                  : 'Categoria atualizada para novos lançamentos.',
+                            ),
+                          ),
+                        );
+                        await context
+                            .read<ExtratoViewModel>()
+                            .carregarGastos();
+                      } catch (_) {
+                        if (!mounted) return;
+                        scaffold.showSnackBar(
+                          const SnackBar(
+                            content: Text(
+                              'Não foi possível atualizar a categoria. Tente novamente.',
+                            ),
+                          ),
+                        );
+                      }
+                    },
+            ),
+          ),
+        );
+      },
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemCount: vm.caches.length,
+    );
+  }
+}

--- a/lib/view/extrato_import_view.dart
+++ b/lib/view/extrato_import_view.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../view_model/extrato_view_model.dart';
+import '../view_model/usuario_view_model.dart';
+
+class ExtratoImportView extends StatefulWidget {
+  const ExtratoImportView({super.key});
+
+  @override
+  State<ExtratoImportView> createState() => _ExtratoImportViewState();
+}
+
+class _ExtratoImportViewState extends State<ExtratoImportView> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _importar() async {
+    final extrato = _controller.text.trim();
+    if (extrato.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Cole o conteúdo do extrato antes de importar.')),
+      );
+      return;
+    }
+
+    final usuario = context.read<UsuarioViewModel>().usuarioLogado;
+    if (usuario == null || usuario.id == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Faça login para importar um extrato.')),
+      );
+      return;
+    }
+
+    final vm = context.read<ExtratoViewModel>();
+    try {
+      final quantidade =
+          await vm.importarExtrato(extrato, usuario.id!);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$quantidade lançamento(s) importado(s) com sucesso.'),
+        ),
+      );
+      Navigator.pop(context);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Falha ao importar extrato: ${vm.importError ?? e.toString()}')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ExtratoViewModel>(
+      builder: (context, vm, child) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Importar extrato'),
+            centerTitle: true,
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                TextField(
+                  controller: _controller,
+                  maxLines: 12,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Cole aqui o conteúdo CSV do extrato...',
+                  ),
+                ),
+                const SizedBox(height: 16),
+                vm.importando
+                    ? const CircularProgressIndicator()
+                    : SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton.icon(
+                          onPressed: _importar,
+                          icon: const Icon(Icons.file_upload),
+                          label: const Text('Importar extrato'),
+                        ),
+                      ),
+                if (vm.importError != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    vm.importError!,
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/view/extrato_view.dart
+++ b/lib/view/extrato_view.dart
@@ -6,6 +6,8 @@ import '../view_model/extrato_view_model.dart';
 import '../view_model/categoria_view_model.dart';
 import 'package:expenses_control/models/gasto.dart';
 import 'gasto_detalhe_view.dart';
+import 'extrato_import_view.dart';
+import 'categoria_cache_view.dart';
 
 class ExtratoView extends StatefulWidget {
   @override
@@ -41,6 +43,20 @@ class _ExtratoViewState extends State<ExtratoView> {
       appBar: AppBar(
         title: Text('Extrato de Gastos'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit_note),
+            tooltip: 'Ajustar categorias sugeridas',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const CategoriaCacheView(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Column(
         children: [
@@ -80,6 +96,18 @@ class _ExtratoViewState extends State<ExtratoView> {
             ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const ExtratoImportView(),
+            ),
+          );
+        },
+        icon: const Icon(Icons.file_upload),
+        label: const Text('Importar extrato'),
       ),
     );
   }

--- a/lib/view/gasto_detalhe_view.dart
+++ b/lib/view/gasto_detalhe_view.dart
@@ -6,6 +6,7 @@ import 'package:expenses_control/models/gasto.dart';
 import '../view_model/categoria_view_model.dart';
 import '../view_model/gasto_view_model.dart';
 import '../view_model/extrato_view_model.dart';
+import '../utils/string_normalizer.dart';
 
 class GastoDetalheView extends StatefulWidget {
   final Gasto gasto;
@@ -55,6 +56,7 @@ class _GastoDetalheViewState extends State<GastoDetalheView> {
       total: double.tryParse(_totalController.text.replaceAll(',', '.')) ??
           widget.gasto.total,
       categoriaId: _categoriaId ?? widget.gasto.categoriaId,
+      descricaoNormalizada: normalizeText(_localController.text),
     );
     await context.read<GastoViewModel>().atualizarGasto(atualizado);
     await context.read<ExtratoViewModel>().carregarGastos();

--- a/lib/view/gasto_view.dart
+++ b/lib/view/gasto_view.dart
@@ -9,6 +9,8 @@ import '../view_model/dashboard_view_model.dart';
 import 'package:expenses_control/models/gasto.dart';
 import 'package:expenses_control/models/categoria.dart';
 
+import '../utils/string_normalizer.dart';
+
 class GastoView extends StatefulWidget {
   final Map<String, dynamic>? dadosIniciais;
 
@@ -179,6 +181,7 @@ class _GastoViewState extends State<GastoView> {
         total: double.tryParse(_totalController.text.replaceAll(',', '.')) ?? 0,
         data: _selectedDate ?? DateTime.now(),
         local: _localidadeController.text,
+        descricaoNormalizada: normalizeText(_localidadeController.text),
       );
       await vm.salvarGasto(gasto);
       // Refresh related view models so other screens update immediately

--- a/lib/view_model/categoria_cache_view_model.dart
+++ b/lib/view_model/categoria_cache_view_model.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:expenses_control/models/categoria.dart';
+
+import '../models/categoria_cache.dart';
+import '../models/data/categoria_cache_repository.dart';
+import '../models/data/categoria_repository.dart';
+
+class CategoriaCacheViewModel extends ChangeNotifier {
+  final CategoriaCacheRepository _cacheRepository;
+  final CategoriaRepository _categoriaRepository;
+
+  CategoriaCacheViewModel({
+    required CategoriaCacheRepository cacheRepository,
+    required CategoriaRepository categoriaRepository,
+  })  : _cacheRepository = cacheRepository,
+        _categoriaRepository = categoriaRepository;
+
+  bool _loading = false;
+  String? _error;
+  int _usuarioId = 0;
+  List<CategoriaCache> _caches = [];
+  List<Categoria> _categorias = [];
+  final Set<int> _atualizando = {};
+
+  bool get loading => _loading;
+  String? get error => _error;
+  List<CategoriaCache> get caches => _caches;
+  List<Categoria> get categorias => _categorias;
+  bool estaAtualizando(int? id) => id != null && _atualizando.contains(id);
+
+  Future<void> carregar(int usuarioId) async {
+    _usuarioId = usuarioId;
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _categorias = await _categoriaRepository.findAll();
+      if (usuarioId == 0) {
+        _caches = [];
+      } else {
+        await _cacheRepository.garantirDescricoesNormalizadas(usuarioId);
+        _caches = await _cacheRepository.findAllByUsuario(usuarioId);
+      }
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Categoria? obterCategoriaPorId(int? id) {
+    if (id == null) return null;
+    return _categorias.firstWhere(
+      (c) => c.id == id,
+      orElse: () => _categorias.isNotEmpty ? _categorias.first : null,
+    );
+  }
+
+  Future<int> atualizarCategoria(CategoriaCache cache, int categoriaId) async {
+    final cacheId = cache.id;
+    if (cacheId == null) return 0;
+    _atualizando.add(cacheId);
+    notifyListeners();
+    try {
+      await _cacheRepository.atualizarCategoria(cacheId, categoriaId);
+      final afetados = await _cacheRepository.aplicarCategoriaParaDescricao(
+        usuarioId: _usuarioId,
+        descricaoNormalizada: cache.descricaoNormalizada,
+        categoriaId: categoriaId,
+      );
+      final idx = _caches.indexWhere((c) => c.id == cacheId);
+      if (idx != -1) {
+        _caches[idx] = cache.copyWith(categoriaId: categoriaId);
+      }
+      _error = null;
+      notifyListeners();
+      return afetados;
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    } finally {
+      _atualizando.remove(cacheId);
+      notifyListeners();
+    }
+  }
+}

--- a/lib/view_model/extrato_view_model.dart
+++ b/lib/view_model/extrato_view_model.dart
@@ -2,15 +2,24 @@ import 'package:expenses_control/models/data/gasto_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:expenses_control/models/gasto.dart';
 
+import '../models/services/extrato_import_service.dart';
+
 class ExtratoViewModel extends ChangeNotifier {
   final GastoRepository _repo;
-  ExtratoViewModel(this._repo);
+  final ExtratoImportService _importService;
+  ExtratoViewModel(this._repo, this._importService);
 
   List<Gasto> _gastos = [];
   bool _loading = false;
+  bool _importing = false;
+  String? _importError;
+  int _ultimoImportados = 0;
 
   List<Gasto> get gastos => _gastos;
   bool get loading => _loading;
+  bool get importando => _importing;
+  String? get importError => _importError;
+  int get ultimoImportados => _ultimoImportados;
 
   Future<void> carregarGastos() async {
     _loading = true;
@@ -18,5 +27,24 @@ class ExtratoViewModel extends ChangeNotifier {
     _gastos = await _repo.findAll();
     _loading = false;
     notifyListeners();
+  }
+
+  Future<int> importarExtrato(String conteudo, int usuarioId) async {
+    _importError = null;
+    _importing = true;
+    notifyListeners();
+    try {
+      final quantidade =
+          await _importService.importarExtrato(conteudo, usuarioId);
+      _ultimoImportados = quantidade;
+      _importing = false;
+      await carregarGastos();
+      return quantidade;
+    } catch (e) {
+      _importError = e.toString();
+      _importing = false;
+      notifyListeners();
+      rethrow;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a descricao_normalizada column to the gastos schema and populate it from imports and manual edits
- extend the categoria cache repository/view model and add a management screen so users can adjust cached mappings
- refresh extrato data after cache edits and cascade category changes to matching gastos

## Testing
- not run (flutter command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68de727bccf08329bdc3989520f83938